### PR TITLE
Add domain events and dispatching infrastructure

### DIFF
--- a/eLetter25.API/Program.cs
+++ b/eLetter25.API/Program.cs
@@ -6,6 +6,8 @@ using eLetter25.Application.Letters.Ports;
 using eLetter25.Application.Letters.UseCases.CreateLetter;
 using eLetter25.Infrastructure.Auth.Data;
 using eLetter25.Infrastructure.Auth.Services;
+using eLetter25.Infrastructure.DomainEvents;
+using eLetter25.Infrastructure.Observability;
 using eLetter25.Infrastructure.Persistence;
 using eLetter25.Infrastructure.Persistence.Letters;
 using eLetter25.Infrastructure.Persistence.Letters.Mappings;
@@ -76,6 +78,9 @@ builder.Services.AddScoped<ILetterDomainToDbMapper, LetterDomainToDbMapper>();
 builder.Services.AddScoped<ILetterDbToDomainMapper, LetterDbToDomainMapper>();
 builder.Services.AddScoped<ILetterRepository, EfLetterRepository>();
 builder.Services.AddScoped<IUnitOfWork, EfUnitOfWork>();
+builder.Services.AddScoped<IDomainEventCollector, DomainEventCollector>();
+builder.Services.AddScoped<IDomainEventDispatcher, MediatRDomainEventDispatcher>();
+builder.Services.AddScoped<IAuditWriter, LoggerAuditWriter>();
 
 // Auth Services
 builder.Services.AddScoped<IJwtTokenGenerator, JwtTokenGenerator>();

--- a/eLetter25.Application/Common/Events/DomainEventNotification.cs
+++ b/eLetter25.Application/Common/Events/DomainEventNotification.cs
@@ -1,0 +1,7 @@
+﻿using eLetter25.Domain.Common;
+using MediatR;
+
+namespace eLetter25.Application.Common.Events;
+
+public sealed record DomainEventNotification<TDomainEvent>(TDomainEvent DomainEvent) : INotification
+    where TDomainEvent : IDomainEvent;

--- a/eLetter25.Application/Common/Models/AuditEntry.cs
+++ b/eLetter25.Application/Common/Models/AuditEntry.cs
@@ -1,0 +1,8 @@
+﻿namespace eLetter25.Application.Common.Models;
+
+public sealed record AuditEntry(
+    string Action,
+    Guid EntityId,
+    string EntityType,
+    DateTimeOffset OccurredOn,
+    IReadOnlyDictionary<string, string> Metadata);

--- a/eLetter25.Application/Common/Ports/IAuditWriter.cs
+++ b/eLetter25.Application/Common/Ports/IAuditWriter.cs
@@ -1,0 +1,8 @@
+﻿using eLetter25.Application.Common.Models;
+
+namespace eLetter25.Application.Common.Ports;
+
+public interface IAuditWriter
+{
+    Task WriteAsync(AuditEntry entry, CancellationToken cancellationToken = default);
+}

--- a/eLetter25.Application/Letters/EventHandlers/LetterCreatedAuditHandler.cs
+++ b/eLetter25.Application/Letters/EventHandlers/LetterCreatedAuditHandler.cs
@@ -1,0 +1,30 @@
+﻿using eLetter25.Application.Common.Events;
+using eLetter25.Application.Common.Models;
+using eLetter25.Application.Common.Ports;
+using eLetter25.Domain.Letters.Events;
+using MediatR;
+
+namespace eLetter25.Application.Letters.EventHandlers;
+
+public sealed class LetterCreatedAuditHandler(IAuditWriter auditWriter)
+    : INotificationHandler<DomainEventNotification<LetterCreatedEvent>>
+{
+    public Task Handle(
+        DomainEventNotification<LetterCreatedEvent> notification,
+        CancellationToken cancellationToken)
+    {
+        var domainEvent = notification.DomainEvent;
+        var entry = new AuditEntry(
+            "LetterCreated",
+            domainEvent.LetterId,
+            nameof(LetterCreatedEvent),
+            domainEvent.OccurredOn,
+            new Dictionary<string, string>
+            {
+                ["SentDate"] = domainEvent.SentDate.ToString("O"),
+                ["CreatedDate"] = domainEvent.CreatedDate.ToString("O"),
+            });
+
+        return auditWriter.WriteAsync(entry, cancellationToken);
+    }
+}

--- a/eLetter25.Application/Letters/EventHandlers/LetterTagAddedAuditHandler.cs
+++ b/eLetter25.Application/Letters/EventHandlers/LetterTagAddedAuditHandler.cs
@@ -1,0 +1,29 @@
+﻿using eLetter25.Application.Common.Events;
+using eLetter25.Application.Common.Models;
+using eLetter25.Application.Common.Ports;
+using eLetter25.Domain.Letters.Events;
+using MediatR;
+
+namespace eLetter25.Application.Letters.EventHandlers;
+
+public sealed class LetterTagAddedAuditHandler(IAuditWriter auditWriter)
+    : INotificationHandler<DomainEventNotification<LetterTagAddedEvent>>
+{
+    public Task Handle(
+        DomainEventNotification<LetterTagAddedEvent> notification,
+        CancellationToken cancellationToken)
+    {
+        var domainEvent = notification.DomainEvent;
+        var entry = new AuditEntry(
+            "LetterTagAdded",
+            domainEvent.LetterId,
+            nameof(LetterTagAddedEvent),
+            domainEvent.OccurredOn,
+            new Dictionary<string, string>
+            {
+                ["Tag"] = domainEvent.Tag,
+            });
+
+        return auditWriter.WriteAsync(entry, cancellationToken);
+    }
+}

--- a/eLetter25.Domain.Tests/Letters/LetterDomainEventTests.cs
+++ b/eLetter25.Domain.Tests/Letters/LetterDomainEventTests.cs
@@ -1,0 +1,51 @@
+﻿using eLetter25.Domain.Letters;
+using eLetter25.Domain.Letters.Events;
+using eLetter25.Domain.Letters.ValueObjects;
+using eLetter25.Domain.Shared.ValueObjects;
+using FluentAssertions;
+
+namespace eLetter25.Domain.Tests.Letters;
+
+public sealed class LetterDomainEventTests
+{
+    [Fact]
+    public void Create_ShouldRaiseLetterCreatedEvent()
+    {
+        var sender = CreateCorrespondent("Sender");
+        var recipient = CreateCorrespondent("Recipient");
+
+        var letter = Letter.Create(sender, recipient, DateTimeOffset.UtcNow);
+
+        letter.DomainEvents.Should().ContainSingle(@event =>
+            @event is LetterCreatedEvent created &&
+            created.LetterId == letter.Id &&
+            created.SentDate == letter.SentDate &&
+            created.CreatedDate == letter.CreatedDate);
+    }
+
+    [Fact]
+    public void AddTag_ShouldRaiseEventOnceAndPreventDuplicates()
+    {
+        var sender = CreateCorrespondent("Sender");
+        var recipient = CreateCorrespondent("Recipient");
+        var letter = Letter.Create(sender, recipient, DateTimeOffset.UtcNow);
+        letter.ClearDomainEvents();
+
+        var tag = new Tag("Urgent");
+        letter.AddTag(tag);
+        letter.AddTag(tag);
+
+        letter.Tags.Should().ContainSingle(t => t.Equals(tag));
+        letter.DomainEvents.Should().ContainSingle(@event =>
+            @event is LetterTagAddedEvent tagEvent &&
+            tagEvent.LetterId == letter.Id &&
+            tagEvent.Tag == tag.Value);
+    }
+
+    private static Correspondent CreateCorrespondent(string name)
+    {
+        return new Correspondent(
+            name,
+            new Address("Main Street", "12345", "Berlin", "DE"));
+    }
+}

--- a/eLetter25.Domain.Tests/eLetter25.Domain.Tests.csproj
+++ b/eLetter25.Domain.Tests/eLetter25.Domain.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\eLetter25.Domain\eLetter25.Domain.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/eLetter25.Domain/Common/DomainEntity.cs
+++ b/eLetter25.Domain/Common/DomainEntity.cs
@@ -6,4 +6,19 @@
 public abstract class DomainEntity
 {
     public Guid Id { get; protected set; } = Guid.NewGuid();
+
+    private readonly List<IDomainEvent> _domainEvents = [];
+
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    protected void Raise(IDomainEvent domainEvent)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        _domainEvents.Add(domainEvent);
+    }
+
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
 }

--- a/eLetter25.Domain/Common/DomainEventBase.cs
+++ b/eLetter25.Domain/Common/DomainEventBase.cs
@@ -1,0 +1,10 @@
+﻿namespace eLetter25.Domain.Common;
+
+/// <summary>
+/// Base type for domain events.
+/// </summary>
+public abstract record DomainEventBase : IDomainEvent
+{
+    public DateTimeOffset OccurredOn { get; init; } = DateTimeOffset.UtcNow;
+    public Guid? CorrelationId { get; init; }
+}

--- a/eLetter25.Domain/Common/IDomainEvent.cs
+++ b/eLetter25.Domain/Common/IDomainEvent.cs
@@ -1,0 +1,10 @@
+﻿namespace eLetter25.Domain.Common;
+
+/// <summary>
+/// Represents a domain event emitted by aggregate roots.
+/// </summary>
+public interface IDomainEvent
+{
+    DateTimeOffset OccurredOn { get; }
+    Guid? CorrelationId { get; }
+}

--- a/eLetter25.Domain/Letters/Events/LetterCreatedEvent.cs
+++ b/eLetter25.Domain/Letters/Events/LetterCreatedEvent.cs
@@ -1,0 +1,8 @@
+﻿using eLetter25.Domain.Common;
+
+namespace eLetter25.Domain.Letters.Events;
+
+public sealed record LetterCreatedEvent(
+    Guid LetterId,
+    DateTimeOffset SentDate,
+    DateTimeOffset CreatedDate) : DomainEventBase;

--- a/eLetter25.Domain/Letters/Events/LetterSubjectChangedEvent.cs
+++ b/eLetter25.Domain/Letters/Events/LetterSubjectChangedEvent.cs
@@ -1,0 +1,8 @@
+﻿using eLetter25.Domain.Common;
+
+namespace eLetter25.Domain.Letters.Events;
+
+public sealed record LetterSubjectChangedEvent(
+    Guid LetterId,
+    string PreviousSubject,
+    string CurrentSubject) : DomainEventBase;

--- a/eLetter25.Domain/Letters/Events/LetterTagAddedEvent.cs
+++ b/eLetter25.Domain/Letters/Events/LetterTagAddedEvent.cs
@@ -1,0 +1,7 @@
+﻿using eLetter25.Domain.Common;
+
+namespace eLetter25.Domain.Letters.Events;
+
+public sealed record LetterTagAddedEvent(
+    Guid LetterId,
+    string Tag) : DomainEventBase;

--- a/eLetter25.Infrastructure.Tests/DomainEvents/DomainEventDispatchTests.cs
+++ b/eLetter25.Infrastructure.Tests/DomainEvents/DomainEventDispatchTests.cs
@@ -1,0 +1,104 @@
+﻿using eLetter25.Domain.Letters;
+using eLetter25.Domain.Letters.ValueObjects;
+using eLetter25.Domain.Shared.ValueObjects;
+using eLetter25.Infrastructure.DomainEvents;
+using eLetter25.Infrastructure.Persistence;
+using eLetter25.Infrastructure.Persistence.Letters;
+using eLetter25.Infrastructure.Persistence.Letters.Mappings;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace eLetter25.Infrastructure.Tests.DomainEvents;
+
+public sealed class DomainEventDispatchTests
+{
+    [Fact]
+    public async Task CommitAsync_ShouldDispatchDomainEventsAfterSaveChanges()
+    {
+        var dispatcher = new TestDomainEventDispatcher();
+        var collector = new DomainEventCollector();
+        await using var dbContext = BuildDbContext();
+        var repository = new EfLetterRepository(
+            dbContext,
+            new LetterDomainToDbMapper(),
+            new LetterDbToDomainMapper(),
+            collector);
+        var unitOfWork = new EfUnitOfWork(dbContext, collector, dispatcher);
+
+        var letter = Letter.Create(CreateCorrespondent("Sender"), CreateCorrespondent("Recipient"), DateTimeOffset.UtcNow);
+
+        await repository.AddAsync(letter);
+        await unitOfWork.CommitAsync();
+
+        dispatcher.DispatchedEvents.Should().HaveCount(1);
+        dispatcher.DispatchedEvents.Single().LetterId.Should().Be(letter.Id);
+    }
+
+    [Fact]
+    public async Task CommitAsync_ShouldNotDispatch_WhenSaveChangesFails()
+    {
+        var dispatcher = new TestDomainEventDispatcher();
+        var collector = new DomainEventCollector();
+        await using var dbContext = BuildDbContext(new FailingSaveChangesInterceptor());
+        var repository = new EfLetterRepository(
+            dbContext,
+            new LetterDomainToDbMapper(),
+            new LetterDbToDomainMapper(),
+            collector);
+        var unitOfWork = new EfUnitOfWork(dbContext, collector, dispatcher);
+
+        var letter = Letter.Create(CreateCorrespondent("Sender"), CreateCorrespondent("Recipient"), DateTimeOffset.UtcNow);
+        await repository.AddAsync(letter);
+
+        var action = () => unitOfWork.CommitAsync();
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Simulated failure");
+        dispatcher.DispatchedEvents.Should().BeEmpty();
+    }
+
+    private static AppDbContext BuildDbContext(SaveChangesInterceptor? interceptor = null)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"eletter25-{Guid.NewGuid()}");
+
+        if (interceptor is not null)
+        {
+            optionsBuilder.AddInterceptors(interceptor);
+        }
+
+        return new AppDbContext(optionsBuilder.Options);
+    }
+
+    private static Correspondent CreateCorrespondent(string name)
+    {
+        return new Correspondent(
+            name,
+            new Address("Main Street", "12345", "Berlin", "DE"));
+    }
+
+    private sealed class FailingSaveChangesInterceptor : SaveChangesInterceptor
+    {
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Simulated failure");
+        }
+    }
+
+    private sealed class TestDomainEventDispatcher : IDomainEventDispatcher
+    {
+        public List<Domain.Letters.Events.LetterCreatedEvent> DispatchedEvents { get; } = [];
+
+        public Task DispatchAsync(
+            IReadOnlyCollection<Domain.Common.IDomainEvent> domainEvents,
+            CancellationToken cancellationToken = default)
+        {
+            DispatchedEvents.AddRange(domainEvents.OfType<Domain.Letters.Events.LetterCreatedEvent>());
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/eLetter25.Infrastructure.Tests/eLetter25.Infrastructure.Tests.csproj
+++ b/eLetter25.Infrastructure.Tests/eLetter25.Infrastructure.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\eLetter25.Application\eLetter25.Application.csproj" />
+        <ProjectReference Include="..\eLetter25.Domain\eLetter25.Domain.csproj" />
+        <ProjectReference Include="..\eLetter25.Infrastructure\eLetter25.Infrastructure.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/eLetter25.Infrastructure/DomainEvents/DomainEventCollector.cs
+++ b/eLetter25.Infrastructure/DomainEvents/DomainEventCollector.cs
@@ -1,0 +1,36 @@
+﻿using eLetter25.Domain.Common;
+
+namespace eLetter25.Infrastructure.DomainEvents;
+
+public sealed class DomainEventCollector : IDomainEventCollector
+{
+    private readonly HashSet<DomainEntity> _trackedEntities = [];
+
+    public void CollectFrom(DomainEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        if (entity.DomainEvents.Count == 0)
+        {
+            return;
+        }
+
+        _trackedEntities.Add(entity);
+    }
+
+    public IReadOnlyCollection<IDomainEvent> GetDomainEvents()
+    {
+        return _trackedEntities
+            .SelectMany(entity => entity.DomainEvents)
+            .ToArray();
+    }
+
+    public void Clear()
+    {
+        foreach (var entity in _trackedEntities)
+        {
+            entity.ClearDomainEvents();
+        }
+
+        _trackedEntities.Clear();
+    }
+}

--- a/eLetter25.Infrastructure/DomainEvents/IDomainEventCollector.cs
+++ b/eLetter25.Infrastructure/DomainEvents/IDomainEventCollector.cs
@@ -1,0 +1,10 @@
+﻿using eLetter25.Domain.Common;
+
+namespace eLetter25.Infrastructure.DomainEvents;
+
+public interface IDomainEventCollector
+{
+    void CollectFrom(DomainEntity entity);
+    IReadOnlyCollection<IDomainEvent> GetDomainEvents();
+    void Clear();
+}

--- a/eLetter25.Infrastructure/DomainEvents/IDomainEventDispatcher.cs
+++ b/eLetter25.Infrastructure/DomainEvents/IDomainEventDispatcher.cs
@@ -1,0 +1,8 @@
+﻿using eLetter25.Domain.Common;
+
+namespace eLetter25.Infrastructure.DomainEvents;
+
+public interface IDomainEventDispatcher
+{
+    Task DispatchAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken = default);
+}

--- a/eLetter25.Infrastructure/DomainEvents/MediatRDomainEventDispatcher.cs
+++ b/eLetter25.Infrastructure/DomainEvents/MediatRDomainEventDispatcher.cs
@@ -1,0 +1,18 @@
+﻿using eLetter25.Application.Common.Events;
+using eLetter25.Domain.Common;
+using MediatR;
+
+namespace eLetter25.Infrastructure.DomainEvents;
+
+public sealed class MediatRDomainEventDispatcher(IMediator mediator) : IDomainEventDispatcher
+{
+    public async Task DispatchAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken = default)
+    {
+        foreach (var domainEvent in domainEvents)
+        {
+            var notificationType = typeof(DomainEventNotification<>).MakeGenericType(domainEvent.GetType());
+            var notification = (INotification)Activator.CreateInstance(notificationType, domainEvent)!;
+            await mediator.Publish(notification, cancellationToken);
+        }
+    }
+}

--- a/eLetter25.Infrastructure/Observability/LoggerAuditWriter.cs
+++ b/eLetter25.Infrastructure/Observability/LoggerAuditWriter.cs
@@ -1,0 +1,21 @@
+﻿using eLetter25.Application.Common.Models;
+using eLetter25.Application.Common.Ports;
+using Microsoft.Extensions.Logging;
+
+namespace eLetter25.Infrastructure.Observability;
+
+public sealed class LoggerAuditWriter(ILogger<LoggerAuditWriter> logger) : IAuditWriter
+{
+    public Task WriteAsync(AuditEntry entry, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation(
+            "Audit event {Action} for {EntityType} {EntityId} at {OccurredOn} with {Metadata}.",
+            entry.Action,
+            entry.EntityType,
+            entry.EntityId,
+            entry.OccurredOn,
+            entry.Metadata);
+
+        return Task.CompletedTask;
+    }
+}

--- a/eLetter25.Infrastructure/Persistence/EfUnitOfWork.cs
+++ b/eLetter25.Infrastructure/Persistence/EfUnitOfWork.cs
@@ -1,11 +1,24 @@
 ﻿using eLetter25.Application.Common.Ports;
+using eLetter25.Infrastructure.DomainEvents;
 
 namespace eLetter25.Infrastructure.Persistence;
 
-public sealed class EfUnitOfWork(AppDbContext dbContext) : IUnitOfWork
+public sealed class EfUnitOfWork(
+    AppDbContext dbContext,
+    IDomainEventCollector domainEventCollector,
+    IDomainEventDispatcher domainEventDispatcher) : IUnitOfWork
 {
     public async Task CommitAsync(CancellationToken cancellationToken = default)
     {
+        var domainEvents = domainEventCollector.GetDomainEvents();
         await dbContext.SaveChangesAsync(cancellationToken);
+
+        if (domainEvents.Count == 0)
+        {
+            return;
+        }
+
+        await domainEventDispatcher.DispatchAsync(domainEvents, cancellationToken);
+        domainEventCollector.Clear();
     }
 }

--- a/eLetter25.Infrastructure/Persistence/Letters/EfLetterRepository.cs
+++ b/eLetter25.Infrastructure/Persistence/Letters/EfLetterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using eLetter25.Application.Letters.Ports;
 using eLetter25.Domain.Letters;
+using eLetter25.Infrastructure.DomainEvents;
 using eLetter25.Infrastructure.Persistence.Letters.Mappings;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,12 +9,14 @@ namespace eLetter25.Infrastructure.Persistence.Letters;
 public sealed class EfLetterRepository(
     AppDbContext dbContext,
     ILetterDomainToDbMapper domainToDbMapper,
-    ILetterDbToDomainMapper dbToDomainMapper) : ILetterRepository
+    ILetterDbToDomainMapper dbToDomainMapper,
+    IDomainEventCollector domainEventCollector) : ILetterRepository
 {
     public async Task AddAsync(Letter letter, CancellationToken cancellationToken = default)
     {
         var entity = domainToDbMapper.MapToDbEntity(letter);
         await dbContext.Letters.AddAsync(entity, cancellationToken);
+        domainEventCollector.CollectFrom(letter);
     }
 
     public async Task<Letter?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)

--- a/eLetter25.Infrastructure/eLetter25.Infrastructure.csproj
+++ b/eLetter25.Infrastructure/eLetter25.Infrastructure.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="MediatR" Version="14.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.1" />

--- a/eLetter25.slnx
+++ b/eLetter25.slnx
@@ -8,6 +8,10 @@
     <Project Path="eLetter25.API/eLetter25.API.csproj" />
     <Project Path="eLetter25.Client/eLetter25.Client.csproj" />
   </Folder>
+  <Folder Name="/Tests/">
+    <Project Path="eLetter25.Domain.Tests/eLetter25.Domain.Tests.csproj" />
+    <Project Path="eLetter25.Infrastructure.Tests/eLetter25.Infrastructure.Tests.csproj" />
+  </Folder>
   <Project Path="eLetter25.Application/eLetter25.Application.csproj" />
   <Project Path="eLetter25.Domain/eLetter25.Domain.csproj" />
   <Project Path="eLetter25.Host/eLetter25.Host.csproj" />


### PR DESCRIPTION
### Motivation
- Introduce first-class Domain Events so aggregates can emit events without depending on MediatR or infrastructure.
- Ensure events are dispatched at the transaction boundary (after successful commit) to avoid side-effects on failed saves.
- Provide a clean Application-facing event handling strategy using MediatR `INotification` adapters and ports for side-effects (e.g. audit), keeping handlers infrastructure-agnostic.

### Description
- Domain: added `IDomainEvent`, `DomainEventBase`, extended `DomainEntity` to collect events (`Raise`, `DomainEvents`, `ClearDomainEvents`), and added `Letter` events (`LetterCreatedEvent`, `LetterSubjectChangedEvent`, `LetterTagAddedEvent`) with event-raising inside the aggregate and duplicate-safe tag handling. 
- Application: added `DomainEventNotification<TDomainEvent>` adapter, `AuditEntry` model, `IAuditWriter` port, and example MediatR notification handlers `LetterCreatedAuditHandler` and `LetterTagAddedAuditHandler` which use `IAuditWriter` instead of direct infrastructure calls. 
- Infrastructure: implemented `IDomainEventCollector` and `DomainEventCollector` to collect domain events from aggregates, `IDomainEventDispatcher` and `MediatRDomainEventDispatcher` to publish events as `INotification`s, modified `EfLetterRepository` to register entities with the collector, and extended `EfUnitOfWork` to `DispatchAsync` events after `SaveChangesAsync` and clear collected events; added `LoggerAuditWriter` as a simple `IAuditWriter` implementation and registered DI in `Program.cs`. 
- Tests & wiring: added `eLetter25.Domain.Tests` with `LetterDomainEventTests` and `eLetter25.Infrastructure.Tests` with `DomainEventDispatchTests`, added `MediatR` to the Infrastructure project and updated the solution to include the new test projects.

### Testing
- Added automated unit tests: `eLetter25.Domain.Tests/Letters/LetterDomainEventTests.cs` (domain unit tests for event raising) and `eLetter25.Infrastructure.Tests/DomainEvents/DomainEventDispatchTests.cs` (integration-style tests for dispatch after commit and failure behavior). 
- Attempted to run `dotnet test eLetter25.slnx` in the environment but the command failed with `dotnet not found`, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968947f34e88320b4c6f28deb192b2c)