### PR TITLE
Update docs to match current architecture and hosting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # eLetter25
 
-Eine ASP.NET Core-Anwendung zur Verwaltung von Briefen und deren Metadaten mit JWT-basierter Authentifizierung.
+Eine ASP.NET Core-Anwendung zur Verwaltung von Briefen und deren Metadaten mit JWT-basierter Authentifizierung und .NET Aspire für lokale Orchestrierung.
 
 ## 🏗️ Architektur
 
@@ -8,8 +8,8 @@ Das Projekt folgt **Clean Architecture** und **Domain-Driven Design (DDD)** mit 
 
 - **Domain** – Geschäftslogik, Entities, Value Objects
 - **Application** – Use Cases, Commands/Handlers (MediatR), Ports (Interfaces)
-- **Infrastructure** – Persistenz (EF Core, SQL Server), Services (JWT, Identity)
-- **API** – REST Controllers (ASP.NET Core MVC)
+- **Infrastructure** – Persistenz (EF Core, SQL Server/PostgreSQL), Services (JWT, Identity), Domain-Event-Dispatch
+- **API** – REST Controllers (ASP.NET Core MVC), OpenAPI/Scalar
 
 ### Architektur-Pattern
 
@@ -17,16 +17,16 @@ Das Projekt folgt **Clean Architecture** und **Domain-Driven Design (DDD)** mit 
 - **Ports & Adapters**: Application definiert Interfaces, Infrastructure implementiert
 - **Repository Pattern**: Datenzugriff abstrahiert
 - **Unit of Work**: Transaktionsgrenzen explizit
+- **Domain Events**: Events aus Domain Entities werden nach Persistenz dispatcht
 
 ## 🛠️ Technologien
 
 - .NET 10.0
-- Entity Framework Core 10
-- SQL Server (Briefe-Datenbank)
-- PostgreSQL (Identity-Datenbank)
-- ASP.NET Core Identity (JWT-Authentifizierung)
-- .NET Aspire (lokale Entwicklung)
-- MediatR (CQRS-Pattern)
+- Entity Framework Core 10 (SQL Server + PostgreSQL)
+- ASP.NET Core Identity + JWT (Login/Register)
+- MediatR (CQRS-Light + Domain Events)
+- .NET Aspire (lokale Orchestrierung)
+- Scalar/OpenAPI für API-Dokumentation
 
 ## 📦 Projekt-Struktur
 
@@ -39,7 +39,7 @@ eLetter25/
 │   │   ├── Ports/                 # Interfaces (IJwtTokenGenerator, etc.)
 │   │   └── UseCases/              # RegisterUser, LoginUser
 │   └── Letters/                   # Letter Management Use Cases
-├── eLetter25.Infrastructure/      # EF Core, SQL Server, Services
+├── eLetter25.Infrastructure/      # EF Core, SQL Server/PostgreSQL, Services
 │   ├── Auth/                      # Authentication Services & Data
 │   │   ├── Data/                  # ApplicationUser, DbContext
 │   │   └── Services/              # JwtTokenGenerator, UserRegistrationService
@@ -47,7 +47,9 @@ eLetter25/
 ├── eLetter25.API/                 # REST API (Controllers)
 │   └── Auth/Controllers/          # RegisterController, LoginController
 ├── eLetter25.Host/                # .NET Aspire Orchestration
-└── eLetter25.Client/              # Angular Frontend
+├── eLetter25.Client/              # Angular Frontend
+├── eLetter25.Domain.Tests/         # Domain Unit Tests
+└── eLetter25.Infrastructure.Tests/ # Infrastructure Tests
 ```
 
 ## 🚀 Schnellstart
@@ -55,11 +57,11 @@ eLetter25/
 ### Voraussetzungen
 
 - **.NET 10.0 SDK** installiert
-- **Docker Desktop** installiert und **gestartet** (wird für SQL Server und PostgreSQL benötigt)
+- **Docker Desktop** installiert und **gestartet** (für SQL Server und PostgreSQL)
 
 ### 1. User Secrets konfigurieren
 
-Der JWT SecretKey muss in den User Secrets des API-Projekts gespeichert werden:
+Der JWT SecretKey muss in den User Secrets des API-Projekts gespeichert werden, da `Jwt:SecretKey` beim Start validiert wird:
 
 ```powershell
 # JWT Secret Key setzen (mindestens 32 Zeichen für HS256)
@@ -75,7 +77,7 @@ Die JWT Expiration Time wird in der `appsettings.json` des API-Projekts konfigur
 dotnet run --project eLetter25.Host
 ```
 
-**Das war's!** Die Datenbank-Migrationen werden automatisch beim Start der API ausgeführt.
+**Das war's!** Die Datenbank-Migrationen werden automatisch beim Start der API im Development-Modus ausgeführt.
 
 - **API:** `https://localhost:7xxx` (Port wird im Terminal angezeigt)
 - **Aspire Dashboard:** `http://localhost:15000`
@@ -87,15 +89,16 @@ dotnet run --project eLetter25.Host
 - `POST /api/auth/register` - Benutzerregistrierung
 - `POST /api/auth/login` - Login (liefert JWT-Token)
 
-### Letters (`/letters`)
-- `POST /letters` - Brief erstellen (erfordert Authentifizierung)
+> Hinweis: Für Letters existiert aktuell nur der Application-Use-Case (CreateLetter) – es gibt noch keinen API-Endpoint dafür.
 
-Vollständige API-Dokumentation: `https://localhost:7xxx/scalar/v1` (Scalar UI)
+### Sonstiges
+- `GET /` - Health/Info-Endpoint (Textantwort)
+
+Vollständige API-Dokumentation (Development): `https://localhost:7xxx/scalar/v1` (Scalar UI)
 
 ## 📖 Dokumentation
 
 Detaillierte Informationen zur Architektur und Entwicklung:
 
-- [Architektur-Dokumentation](docs/Architektur.md)
+- [Architektur-Dokumentation](Architektur.md)
 - [Coding-Guidelines](.github/copilot-instructions.md)
-


### PR DESCRIPTION
### Motivation
- Die Dokumentation sollte den aktuellen Stand des Repositories widerspiegeln (Auth mit ASP.NET Identity + PostgreSQL, EF Core für Letters, Domain Events, Aspire-Host-Setup). 
- Hinweise zum Start/Quickstart und den erwarteten Endpunkten mussten an die aktuelle `Program.cs`/Host-Konfiguration angepasst werden. 
- Bekannte Probleme und Roadmap sollten mit dem tatsächlichen Codestatus (z.B. fehlender Letters-API-Endpoint) übereinstimmen.

### Description
- Aktualisiert `docs/README.md` um den derzeitigen Tech-Stack, Quickstart-Hinweis (`dotnet run --project eLetter25.Host`) und den Hinweis, dass `Jwt:SecretKey` beim Start validiert wird, sowie die Info, dass der `CreateLetter`-Use-Case derzeit noch keinen API-Endpoint hat. 
- Überarbeitet `docs/Architektur.md` und ergänzt Erläuterungen zu Domain Events, dem Domain-Event-Dispatch im `EfUnitOfWork`, `JwtOptions`-Binding und Start-Validierung, sowie die aktuelle Aspire-Host-Ressourcen-Konfiguration (PostgreSQL + SQL Server + Client). 
- Ergänzt Beobachtbarkeit/Audit-Informationen, Beispiel-Event-Handler in der Application-Schicht, OpenAPI/Scalar-Mapping-Hinweis (nur Development) und die überarbeitete Known-Issues/Roadmap-Liste. 
- Korrigiert Links/Referenzen in den Dokumenten und ergänzt Testprojekte/Ordner-Hinweise in der Projektstruktur-Darstellung.

### Testing
- Nur Dokumentationsänderungen wurden vorgenommen und keine automatisierten Tests ausgeführt. 
- Keinen Build-/Unit-/Integrationstest laufen gelassen (`dotnet test` wurde nicht ausgeführt). 
- Änderungen wurden lokal committed; es wurden keine Code-Änderungen kompiliert oder zur Laufzeit verifiziert.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba625a7c4832091a054402b0ce129)